### PR TITLE
fix: 修复图片收藏页 Hero tag 重复导致崩溃

### DIFF
--- a/lib/pages/image_favorites_page/image_favorites_item.dart
+++ b/lib/pages/image_favorites_page/image_favorites_item.dart
@@ -190,7 +190,7 @@ class _ImageFavoritesItemState extends State<_ImageFavoritesItem> {
               ),
               clipBehavior: Clip.antiAlias,
               child: Hero(
-                tag: "${image.sourceKey}${image.ep}${image.page}",
+                tag: "${image.id}_${image.ep}_${image.page}",
                 child: AnimatedImage(
                   image: ImageFavoritesProvider(image),
                   width: 96,

--- a/lib/pages/image_favorites_page/image_favorites_photo_view.dart
+++ b/lib/pages/image_favorites_page/image_favorites_photo_view.dart
@@ -68,7 +68,7 @@ class _ImageFavoritesPhotoViewState extends State<ImageFavoritesPhotoView> {
         });
       },
       heroAttributes: PhotoViewHeroAttributes(
-        tag: "${image.sourceKey}${image.ep}${image.page}",
+        tag: "${image.id}_${image.ep}_${image.page}",
       ),
     );
   }


### PR DESCRIPTION
- 图片收藏列表页和图片浏览页的 Hero tag 使用 `sourceKey + ep + page` 拼接，不同漫画的同话同页图片会产生相同 tag，触发 Flutter 的重复 Hero tag 异常
- 改用 `id + ep + page` 拼接，包含漫画唯一 `id`，确保 tag 全局唯一

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 改进了图片收藏夹的动画过渡效果，优化了图片预览和详情视图之间的动画匹配机制，提升了整体的视觉过渡体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->