### PR TITLE
feat: 历史记录页面支持时间分组与标题搜索

### DIFF
--- a/assets/translation.json
+++ b/assets/translation.json
@@ -444,7 +444,11 @@
     "Clear specific reader settings for this device": "清除该设备的特殊阅读设置",
     "Enable device specific settings": "启用此设备特定设置",
     "Ignore Certificate Errors": "忽略证书错误",
-    "Mouse scroll speed": "鼠标滚动速度"
+    "Mouse scroll speed": "鼠标滚动速度",
+    "Earlier": "更早",
+    "This Week": "本周",
+    "Today": "今天",
+    "Yesterday": "昨天"
   },
   "zh_TW": {
     "Home": "首頁",
@@ -891,6 +895,10 @@
     "Clear specific reader settings for this device": "清除該裝置的特殊閱讀設定",
     "Enable device specific settings": "啟用此裝置特定設定",
     "Ignore Certificate Errors": "忽略證書錯誤",
-    "Mouse scroll speed": "滑鼠滾動速度"
+    "Mouse scroll speed": "滑鼠滾動速度",
+    "Earlier": "更早",
+    "This Week": "本週",
+    "Today": "今天",
+    "Yesterday": "昨天"
   }
 }

--- a/docs/superpowers/plans/2026-04-14-history-enhancement.md
+++ b/docs/superpowers/plans/2026-04-14-history-enhancement.md
@@ -1,0 +1,359 @@
+# History Page Enhancement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add time-based grouping (Today/Yesterday/This Week/Earlier) and title search to the history page.
+
+**Architecture:** Refactor `history_page.dart` to group the flat `List<History>` into time buckets before rendering. Each bucket gets a `SliverToBoxAdapter` header + `SliverGridComics`. Add a search mode that filters by title before grouping. All existing functionality (multi-select, delete, refresh, clear) is preserved.
+
+**Tech Stack:** Flutter/Dart, existing `SliverGridComics` and `SliverAppbar` components, `assets/translation.json` for i18n.
+
+---
+
+### Task 1: Add translation keys
+
+**Files:**
+- Modify: `assets/translation.json`
+
+- [ ] **Step 1: Add new translation entries for both locales**
+
+Add the following keys to the `"zh_CN"` object (alphabetically near existing entries):
+
+```json
+"Earlier": "更早",
+"This Week": "本周",
+"Today": "今天",
+"Yesterday": "昨天"
+```
+
+Add the same keys to the `"zh_TW"` object:
+
+```json
+"Earlier": "更早",
+"This Week": "本週",
+"Today": "今天",
+"Yesterday": "昨天"
+```
+
+Note: `"Search History"` already exists in both locales.
+
+- [ ] **Step 2: Verify JSON is valid**
+
+Run: `python3 -c "import json; json.load(open('assets/translation.json')); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add assets/translation.json
+git commit -m "feat: add translation keys for history page grouping"
+```
+
+---
+
+### Task 2: Add grouping logic and refactor HistoryPage
+
+**Files:**
+- Modify: `lib/pages/history_page.dart`
+
+- [ ] **Step 1: Add grouping method to `_HistoryPageState`**
+
+Add the following method after the `invertSelection` method (around line 66). This converts a flat list into grouped entries:
+
+```dart
+enum _HistoryGroup { today, yesterday, week, earlier }
+
+extension _HistoryGroupLabel on _HistoryGroup {
+  String get label => switch (this) {
+    _HistoryGroup.today => 'Today',
+    _HistoryGroup.yesterday => 'Yesterday',
+    _HistoryGroup.week => 'This Week',
+    _HistoryGroup.earlier => 'Earlier',
+  };
+}
+```
+
+Add this method inside `_HistoryPageState`:
+
+```dart
+Map<_HistoryGroup, List<History>> _groupByTime(List<History> comics) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final yesterday = today.subtract(const Duration(days: 1));
+  final weekAgo = today.subtract(const Duration(days: 7));
+
+  final groups = <_HistoryGroup, List<History>>{};
+  for (final comic in comics) {
+    final comicDate = DateTime(
+      comic.time.year,
+      comic.time.month,
+      comic.time.day,
+    );
+    final _HistoryGroup group;
+    if (!comicDate.isBefore(today)) {
+      group = _HistoryGroup.today;
+    } else if (!comicDate.isBefore(yesterday)) {
+      group = _HistoryGroup.yesterday;
+    } else if (!comicDate.isBefore(weekAgo)) {
+      group = _HistoryGroup.week;
+    } else {
+      group = _HistoryGroup.earlier;
+    }
+    groups.putIfAbsent(group, () => []).add(comic);
+  }
+  return groups;
+}
+```
+
+- [ ] **Step 2: Add search state fields**
+
+Add these fields to `_HistoryPageState` (after `selectedComics`, around line 45):
+
+```dart
+bool _isSearchMode = false;
+String _searchQuery = '';
+```
+
+Update the `onUpdate` method to also clear selected comics that are no longer in the filtered list. Replace the existing `onUpdate`:
+
+```dart
+void onUpdate() {
+  setState(() {
+    comics = HistoryManager().getAll();
+    if (multiSelectMode) {
+      selectedComics.removeWhere((comic, _) => !comics.contains(comic));
+      if (selectedComics.isEmpty) {
+        multiSelectMode = false;
+      }
+    }
+  });
+}
+```
+
+(This is the same logic — no change needed to `onUpdate` itself. The filtering happens in the getter below.)
+
+Add a getter for filtered + grouped comics:
+
+```dart
+List<History> get _filteredComics {
+  if (_searchQuery.isEmpty) return comics;
+  final query = _searchQuery.toLowerCase();
+  return comics.where((c) => c.title.toLowerCase().contains(query)).toList();
+}
+```
+
+- [ ] **Step 3: Replace the build method's sliver body**
+
+Replace the `SliverGridComics` widget and everything after the `SliverAppbar` in the `build` method (lines 273-313 inside the `SmoothCustomScrollView` slivers list) with the grouped rendering logic:
+
+Remove the single `SliverGridComics(...)` block (lines 273-313).
+
+Add in its place:
+
+```dart
+..._buildGroupedSlivers(context),
+```
+
+Add this method to `_HistoryPageState`:
+
+```dart
+List<Widget> _buildGroupedSlivers(BuildContext context) {
+  final filtered = _filteredComics;
+  final groups = _groupByTime(filtered);
+  final slivers = <Widget>[];
+
+  for (final group in _HistoryGroup.values) {
+    final items = groups[group];
+    if (items == null || items.isEmpty) continue;
+
+    slivers.add(SliverToBoxAdapter(
+      child: Container(
+        padding: const EdgeInsets.only(
+          left: 16,
+          top: 16,
+          bottom: 4,
+        ),
+        child: Text(
+          group.label.tl,
+          style: ts.s14.copyWith(
+            fontWeight: FontWeight.w600,
+            color: context.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ),
+    ));
+
+    slivers.add(SliverGridComics(
+      comics: items,
+      selections: selectedComics,
+      onLongPressed: null,
+      onTap: multiSelectMode
+          ? (c, heroID) {
+              setState(() {
+                if (selectedComics.containsKey(c as History)) {
+                  selectedComics.remove(c);
+                } else {
+                  selectedComics[c] = true;
+                }
+                if (selectedComics.isEmpty) {
+                  multiSelectMode = false;
+                }
+              });
+            }
+          : null,
+      badgeBuilder: (c) {
+        return ComicSource.find(c.sourceKey)?.name;
+      },
+      menuBuilder: (c) {
+        return [
+          MenuEntry(
+            icon: Icons.refresh,
+            text: 'Refresh Info'.tl,
+            onClick: () {
+              _refreshHistory(c as History);
+            },
+          ),
+          MenuEntry(
+            icon: Icons.remove,
+            text: 'Remove'.tl,
+            color: context.colorScheme.error,
+            onClick: () {
+              _removeHistory(c as History);
+            },
+          ),
+        ];
+      },
+    ));
+  }
+
+  if (filtered.isEmpty) {
+    slivers.add(SliverToBoxAdapter(
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 64),
+        child: Center(
+          child: Text(
+            _searchQuery.isEmpty ? 'No history'.tl : 'No results'.tl,
+            style: ts.withColor(context.colorScheme.onSurfaceVariant),
+          ),
+        ),
+      ),
+    ));
+  }
+
+  return slivers;
+}
+```
+
+- [ ] **Step 4: Add search mode to AppBar**
+
+Modify the `normalActions` list in the `build` method. Add a search icon button as the first item in `normalActions` (before the refresh button):
+
+```dart
+IconButton(
+  icon: const Icon(Icons.search),
+  tooltip: 'Search History'.tl,
+  onPressed: () {
+    setState(() {
+      _isSearchMode = true;
+    });
+  },
+),
+```
+
+Modify the `SliverAppbar` in the `build` method. Replace the `title:` parameter logic:
+
+Change:
+```dart
+title: multiSelectMode
+    ? Text(selectedComics.length.toString())
+    : Text('History'.tl),
+```
+
+To:
+```dart
+title: multiSelectMode
+    ? Text(selectedComics.length.toString())
+    : _isSearchMode
+        ? SizedBox(
+            height: 40,
+            child: TextField(
+              autofocus: true,
+              style: ts.s16,
+              decoration: InputDecoration(
+                hintText: 'Search History'.tl,
+                border: InputBorder.none,
+              ),
+              onChanged: (value) {
+                setState(() {
+                  _searchQuery = value;
+                });
+              },
+            ),
+          )
+        : Text('History'.tl),
+```
+
+In search mode, replace `normalActions` with just a close button. Modify the `actions:` assignment:
+
+Change:
+```dart
+actions: multiSelectMode ? selectActions : normalActions,
+```
+
+To:
+```dart
+actions: multiSelectMode
+    ? selectActions
+    : _isSearchMode
+        ? [
+            IconButton(
+              icon: const Icon(Icons.close),
+              tooltip: 'Cancel'.tl,
+              onPressed: () {
+                setState(() {
+                  _isSearchMode = false;
+                  _searchQuery = '';
+                });
+              },
+            ),
+          ]
+        : normalActions,
+```
+
+Also update the leading button's back behavior to exit search mode:
+
+In the `SliverAppbar`'s `leading` (which is currently not set in the non-multiSelect case — the default back button handles it). The `PopScope` at the bottom of `build` needs updating too. Change `onPopInvokedWithResult`:
+
+```dart
+onPopInvokedWithResult: (didPop, result) {
+  if (multiSelectMode) {
+    setState(() {
+      multiSelectMode = false;
+      selectedComics.clear();
+    });
+  } else if (_isSearchMode) {
+    setState(() {
+      _isSearchMode = false;
+      _searchQuery = '';
+    });
+  }
+},
+```
+
+And update `canPop`:
+
+```dart
+canPop: !multiSelectMode && !_isSearchMode,
+```
+
+- [ ] **Step 5: Verify the app builds**
+
+Run: `flutter analyze lib/pages/history_page.dart`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/pages/history_page.dart
+git commit -m "feat: add time-based grouping and title search to history page"
+```

--- a/docs/superpowers/specs/2026-04-14-history-enhancement-design.md
+++ b/docs/superpowers/specs/2026-04-14-history-enhancement-design.md
@@ -1,0 +1,57 @@
+# History Page Enhancement Design
+
+## Overview
+
+Enhance the history page (`lib/pages/history_page.dart`) with time-based grouping and title search, keeping all existing functionality (multi-select, delete, refresh, clear) intact.
+
+## Changes
+
+### 1. Time-based Grouping
+
+Group `List<History>` into four categories before rendering:
+
+| Group | Condition | Display Key |
+|-------|-----------|-------------|
+| Today | Same calendar day as now | `"Today"` |
+| Yesterday | Previous calendar day | `"Yesterday"` |
+| This Week | Within last 7 days but not today/yesterday | `"This Week"` |
+| Earlier | More than 7 days ago | `"Earlier"` |
+
+**Rendering:** Replace the single `SliverGridComics` with a loop over groups. Each group renders:
+1. `SliverToBoxAdapter` with a header container (left-aligned, `onSurfaceVariant` color, `fontSize: 14`, `fontWeight: w600`, 8px vertical padding)
+2. `SliverGridComics` for that group's comics (reuse existing component)
+
+Empty groups are skipped entirely.
+
+### 2. Title Search
+
+**Trigger:** New search icon button (`Icons.search`) in AppBar `normalActions`.
+
+**Behavior:** Tap toggles `_isSearchMode`. In search mode:
+- AppBar title becomes a `TextField` with hint "Search History"
+- `_searchQuery` filters comics by case-insensitive title match before grouping
+- Existing action buttons (multi-select, clear, refresh) are hidden
+- A close button exits search mode and clears the query
+
+**Filtering:** On every query change, re-filter `HistoryManager().getAll()` then regroup. No database query needed — all filtering is in-memory on the existing list.
+
+### 3. Translations
+
+Add to `assets/translation.json`:
+- `"Today"`, `"Yesterday"`, `"This Week"`, `"Earlier"`, `"Search History"`
+
+Translations follow the existing `.tl` extension pattern.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/pages/history_page.dart` | Add `_isSearchMode`, `_searchQuery`, grouping method, rebuild sliver list |
+| `assets/translation.json` | Add new translation keys |
+
+## Unchanged
+
+- `HistoryManager` — no data layer changes
+- `SliverGridComics` — reused as-is for each group
+- Multi-select, delete, refresh info, refresh all, clear history — all preserved
+- `badgeBuilder` and `menuBuilder` on comic tiles — preserved

--- a/lib/components/comic.dart
+++ b/lib/components/comic.dart
@@ -519,8 +519,8 @@ class ComicTile extends StatelessWidget {
                   appdata.saveData();
                   context.showMessage(message: 'Blocked'.tl);
                   comicTileContext
-                      .findAncestorStateOfType<_SliverGridComicsState>()!
-                      .update();
+                      .findAncestorStateOfType<_SliverGridComicsState>()
+                      ?.update();
                 },
                 child: Text('Block'.tl),
               ),

--- a/lib/components/comic.dart
+++ b/lib/components/comic.dart
@@ -513,9 +513,13 @@ class ComicTile extends StatelessWidget {
               Button.filled(
                 onPressed: () {
                   context.pop();
+                  final blockedWords =
+                      appdata.settings['blockedWords'] as List;
                   for (var word in words) {
-                    appdata.settings['blockedWords'].add(word);
+                    blockedWords.add(word);
                   }
+                  // 触发 Settings.notifyListeners，使监听者刷新
+                  appdata.settings['blockedWords'] = blockedWords;
                   appdata.saveData();
                   context.showMessage(message: 'Blocked'.tl);
                   comicTileContext

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:venera/components/components.dart';
 import 'package:venera/foundation/app.dart';
+import 'package:venera/foundation/appdata.dart';
 import 'package:venera/foundation/comic_source/comic_source.dart';
 import 'package:venera/foundation/comic_type.dart';
 import 'package:venera/foundation/history.dart';
@@ -537,12 +538,39 @@ class _SliverGridComicsNoListenerState
       }
     }
     generateHeroID();
+    appdata.settings.addListener(_onSettingsChanged);
     super.initState();
   }
 
   @override
+  void dispose() {
+    appdata.settings.removeListener(_onSettingsChanged);
+    super.dispose();
+  }
+
+  void _onSettingsChanged() {
+    // 重新过滤漫画列表，屏蔽词变化时移除被屏蔽的漫画
+    var changed = false;
+    final newComics = <Comic>[];
+    for (var comic in widget.comics) {
+      if (isBlocked(comic) == null) {
+        newComics.add(comic);
+      } else {
+        changed = true;
+      }
+    }
+    if (changed || newComics.length != comics.length) {
+      setState(() {
+        comics
+          ..clear()
+          ..addAll(newComics);
+      });
+    }
+  }
+
+  @override
   void didUpdateWidget(covariant _SliverGridComicsNoListener oldWidget) {
-    if (!comics.isEqualTo(widget.comics)) {
+    if (!oldWidget.comics.isEqualTo(widget.comics)) {
       comics.clear();
       for (var comic in widget.comics) {
         if (isBlocked(comic) == null) {

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -4,6 +4,7 @@ import 'package:venera/foundation/app.dart';
 import 'package:venera/foundation/comic_source/comic_source.dart';
 import 'package:venera/foundation/comic_type.dart';
 import 'package:venera/foundation/history.dart';
+import 'package:venera/utils/ext.dart';
 import 'package:venera/utils/translations.dart';
 
 class HistoryPage extends StatefulWidget {
@@ -217,7 +218,7 @@ class _HistoryPageState extends State<HistoryPage> {
         ),
       ));
 
-      slivers.add(SliverGridComics(
+      slivers.add(_SliverGridComicsNoListener(
         comics: items,
         selections: selectedComics,
         onLongPressed: null,
@@ -482,5 +483,117 @@ class _HistoryPageState extends State<HistoryPage> {
       });
     }
     return res;
+  }
+}
+
+/// A version of SliverGridComics that does NOT listen to HistoryManager.
+///
+/// The parent _HistoryPageState already listens to HistoryManager and calls
+/// setState, which rebuilds this widget with updated comics. If this widget
+/// also listens, it triggers a setState inside didUpdateWidget's check, causing
+/// the widget to lose its state (like scroll position) and making search/filter
+/// behave incorrectly.
+class _SliverGridComicsNoListener extends StatefulWidget {
+  const _SliverGridComicsNoListener({
+    required this.comics,
+    this.selections,
+    this.onLongPressed,
+    this.onTap,
+    this.badgeBuilder,
+    this.menuBuilder,
+  });
+
+  final List<Comic> comics;
+  final Map<Comic, bool>? selections;
+  final void Function(Comic, int)? onLongPressed;
+  final void Function(Comic, int)? onTap;
+  final String? Function(Comic)? badgeBuilder;
+  final List<MenuEntry> Function(Comic)? menuBuilder;
+
+  @override
+  State<_SliverGridComicsNoListener> createState() =>
+      _SliverGridComicsNoListenerState();
+}
+
+class _SliverGridComicsNoListenerState
+    extends State<_SliverGridComicsNoListener> {
+  List<Comic> comics = [];
+  List<int> heroIDs = [];
+
+  static int _nextHeroID = 0;
+
+  void generateHeroID() {
+    heroIDs.clear();
+    for (var i = 0; i < comics.length; i++) {
+      heroIDs.add(_nextHeroID++);
+    }
+  }
+
+  @override
+  void initState() {
+    for (var comic in widget.comics) {
+      if (isBlocked(comic) == null) {
+        comics.add(comic);
+      }
+    }
+    generateHeroID();
+    super.initState();
+  }
+
+  @override
+  void didUpdateWidget(covariant _SliverGridComicsNoListener oldWidget) {
+    if (!comics.isEqualTo(widget.comics)) {
+      comics.clear();
+      for (var comic in widget.comics) {
+        if (isBlocked(comic) == null) {
+          comics.add(comic);
+        }
+      }
+      generateHeroID();
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverGrid(
+      delegate: SliverChildBuilderDelegate((context, index) {
+        var badge = widget.badgeBuilder?.call(comics[index]);
+        var isSelected = widget.selections == null
+            ? false
+            : widget.selections![comics[index]] ?? false;
+        var comic = ComicTile(
+          comic: comics[index],
+          badge: badge,
+          menuOptions: widget.menuBuilder?.call(comics[index]),
+          onTap: widget.onTap != null
+              ? () => widget.onTap!(comics[index], heroIDs[index])
+              : null,
+          onLongPressed: widget.onLongPressed != null
+              ? () => widget.onLongPressed!(comics[index], heroIDs[index])
+              : null,
+          heroID: heroIDs[index],
+        );
+        if (widget.selections == null) {
+          return comic;
+        }
+        return AnimatedContainer(
+          key: ValueKey(comics[index].id),
+          duration: const Duration(milliseconds: 150),
+          decoration: BoxDecoration(
+            color: isSelected
+                ? Theme.of(context)
+                    .colorScheme
+                    .secondaryContainer
+                    .toOpacity(0.72)
+                : null,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          margin: const EdgeInsets.all(4),
+          child: comic,
+        );
+      }, childCount: comics.length),
+      gridDelegate: SliverGridDelegateWithComics(),
+    );
   }
 }

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -564,6 +564,7 @@ class _SliverGridComicsNoListenerState
         comics
           ..clear()
           ..addAll(newComics);
+        generateHeroID();
       });
     }
   }

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -13,6 +13,17 @@ class HistoryPage extends StatefulWidget {
   State<HistoryPage> createState() => _HistoryPageState();
 }
 
+enum _HistoryGroup { today, yesterday, week, earlier }
+
+extension _HistoryGroupLabel on _HistoryGroup {
+  String get label => switch (this) {
+    _HistoryGroup.today => 'Today',
+    _HistoryGroup.yesterday => 'Yesterday',
+    _HistoryGroup.week => 'This Week',
+    _HistoryGroup.earlier => 'Earlier',
+  };
+}
+
 class _HistoryPageState extends State<HistoryPage> {
   @override
   void initState() {
@@ -43,6 +54,9 @@ class _HistoryPageState extends State<HistoryPage> {
 
   bool multiSelectMode = false;
   Map<History, bool> selectedComics = {};
+
+  bool _isSearchMode = false;
+  String _searchQuery = '';
 
   void selectAll() {
     setState(() {
@@ -143,6 +157,126 @@ class _HistoryPageState extends State<HistoryPage> {
     }
   }
 
+  List<History> get _filteredComics {
+    if (_searchQuery.isEmpty) return comics;
+    final query = _searchQuery.toLowerCase();
+    return comics.where((c) => c.title.toLowerCase().contains(query)).toList();
+  }
+
+  Map<_HistoryGroup, List<History>> _groupByTime(List<History> comics) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final weekAgo = today.subtract(const Duration(days: 7));
+
+    final groups = <_HistoryGroup, List<History>>{};
+    for (final comic in comics) {
+      final comicDate = DateTime(
+        comic.time.year,
+        comic.time.month,
+        comic.time.day,
+      );
+      final _HistoryGroup group;
+      if (!comicDate.isBefore(today)) {
+        group = _HistoryGroup.today;
+      } else if (!comicDate.isBefore(yesterday)) {
+        group = _HistoryGroup.yesterday;
+      } else if (!comicDate.isBefore(weekAgo)) {
+        group = _HistoryGroup.week;
+      } else {
+        group = _HistoryGroup.earlier;
+      }
+      groups.putIfAbsent(group, () => []).add(comic);
+    }
+    return groups;
+  }
+
+  List<Widget> _buildGroupedSlivers(BuildContext context) {
+    final filtered = _filteredComics;
+    final groups = _groupByTime(filtered);
+    final slivers = <Widget>[];
+
+    for (final group in _HistoryGroup.values) {
+      final items = groups[group];
+      if (items == null || items.isEmpty) continue;
+
+      slivers.add(SliverToBoxAdapter(
+        child: Container(
+          padding: const EdgeInsets.only(
+            left: 16,
+            top: 16,
+            bottom: 4,
+          ),
+          child: Text(
+            group.label.tl,
+            style: ts.s14.copyWith(
+              fontWeight: FontWeight.w600,
+              color: context.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ));
+
+      slivers.add(SliverGridComics(
+        comics: items,
+        selections: selectedComics,
+        onLongPressed: null,
+        onTap: multiSelectMode
+            ? (c, heroID) {
+                setState(() {
+                  if (selectedComics.containsKey(c as History)) {
+                    selectedComics.remove(c);
+                  } else {
+                    selectedComics[c] = true;
+                  }
+                  if (selectedComics.isEmpty) {
+                    multiSelectMode = false;
+                  }
+                });
+              }
+            : null,
+        badgeBuilder: (c) {
+          return ComicSource.find(c.sourceKey)?.name;
+        },
+        menuBuilder: (c) {
+          return [
+            MenuEntry(
+              icon: Icons.refresh,
+              text: 'Refresh Info'.tl,
+              onClick: () {
+                _refreshHistory(c as History);
+              },
+            ),
+            MenuEntry(
+              icon: Icons.remove,
+              text: 'Remove'.tl,
+              color: context.colorScheme.error,
+              onClick: () {
+                _removeHistory(c as History);
+              },
+            ),
+          ];
+        },
+      ));
+    }
+
+    if (filtered.isEmpty) {
+      slivers.add(SliverToBoxAdapter(
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 64),
+          child: Center(
+            child: Text(
+              _searchQuery.isEmpty ? 'No history'.tl : 'No results'.tl,
+              style: ts.withColor(context.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        ),
+      ));
+    }
+
+    return slivers;
+  }
+
   @override
   Widget build(BuildContext context) {
     List<Widget> selectActions = [
@@ -181,6 +315,15 @@ class _HistoryPageState extends State<HistoryPage> {
     ];
 
     List<Widget> normalActions = [
+      IconButton(
+        icon: const Icon(Icons.search),
+        tooltip: 'Search History'.tl,
+        onPressed: () {
+          setState(() {
+            _isSearchMode = true;
+          });
+        },
+      ),
       IconButton(
         icon: const Icon(Icons.refresh),
         tooltip: 'Refresh All Histories'.tl,
@@ -234,12 +377,17 @@ class _HistoryPageState extends State<HistoryPage> {
     ];
 
     return PopScope(
-      canPop: !multiSelectMode,
+      canPop: !multiSelectMode && !_isSearchMode,
       onPopInvokedWithResult: (didPop, result) {
         if (multiSelectMode) {
           setState(() {
             multiSelectMode = false;
             selectedComics.clear();
+          });
+        } else if (_isSearchMode) {
+          setState(() {
+            _isSearchMode = false;
+            _searchQuery = '';
           });
         }
       },
@@ -267,50 +415,42 @@ class _HistoryPageState extends State<HistoryPage> {
               ),
               title: multiSelectMode
                   ? Text(selectedComics.length.toString())
-                  : Text('History'.tl),
-              actions: multiSelectMode ? selectActions : normalActions,
+                  : _isSearchMode
+                      ? SizedBox(
+                          height: 40,
+                          child: TextField(
+                            autofocus: true,
+                            style: ts.s16,
+                            decoration: InputDecoration(
+                              hintText: 'Search History'.tl,
+                              border: InputBorder.none,
+                            ),
+                            onChanged: (value) {
+                              setState(() {
+                                _searchQuery = value;
+                              });
+                            },
+                          ),
+                        )
+                      : Text('History'.tl),
+              actions: multiSelectMode
+                  ? selectActions
+                  : _isSearchMode
+                      ? [
+                          IconButton(
+                            icon: const Icon(Icons.close),
+                            tooltip: 'Cancel'.tl,
+                            onPressed: () {
+                              setState(() {
+                                _isSearchMode = false;
+                                _searchQuery = '';
+                              });
+                            },
+                          ),
+                        ]
+                      : normalActions,
             ),
-            SliverGridComics(
-              comics: comics,
-              selections: selectedComics,
-              onLongPressed: null,
-              onTap: multiSelectMode
-                  ? (c, heroID) {
-                      setState(() {
-                        if (selectedComics.containsKey(c as History)) {
-                          selectedComics.remove(c);
-                        } else {
-                          selectedComics[c] = true;
-                        }
-                        if (selectedComics.isEmpty) {
-                          multiSelectMode = false;
-                        }
-                      });
-                    }
-                  : null,
-              badgeBuilder: (c) {
-                return ComicSource.find(c.sourceKey)?.name;
-              },
-              menuBuilder: (c) {
-                return [
-                  MenuEntry(
-                    icon: Icons.refresh,
-                    text: 'Refresh Info'.tl,
-                    onClick: () {
-                      _refreshHistory(c as History);
-                    },
-                  ),
-                  MenuEntry(
-                    icon: Icons.remove,
-                    text: 'Remove'.tl,
-                    color: context.colorScheme.error,
-                    onClick: () {
-                      _removeHistory(c as History);
-                    },
-                  ),
-                ];
-              },
-            ),
+            ..._buildGroupedSlivers(context),
           ],
         ),
       ),

--- a/lib/pages/history_page.dart
+++ b/lib/pages/history_page.dart
@@ -396,7 +396,11 @@ class _HistoryPageState extends State<HistoryPage> {
           slivers: [
             SliverAppbar(
               leading: Tooltip(
-                message: multiSelectMode ? "Cancel".tl : "Back".tl,
+                message: multiSelectMode
+                    ? "Cancel".tl
+                    : _isSearchMode
+                        ? "Cancel".tl
+                        : "Back".tl,
                 child: IconButton(
                   onPressed: () {
                     if (multiSelectMode) {
@@ -404,11 +408,16 @@ class _HistoryPageState extends State<HistoryPage> {
                         multiSelectMode = false;
                         selectedComics.clear();
                       });
+                    } else if (_isSearchMode) {
+                      setState(() {
+                        _isSearchMode = false;
+                        _searchQuery = '';
+                      });
                     } else {
                       context.pop();
                     }
                   },
-                  icon: multiSelectMode
+                  icon: multiSelectMode || _isSearchMode
                       ? const Icon(Icons.close)
                       : const Icon(Icons.arrow_back),
                 ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 历史页面按时间分组显示（今天、昨天、本周、更早）
  * 历史页面支持按标题搜索，进入搜索时 AppBar 切换为搜索输入并可退出搜索

* **改进**
  * 保留并兼容多选、刷新与移除操作，搜索与多选行为相互适配
  * 屏蔽操作更可靠，能正确触发列表刷新

* **文档**
  * 新增历史页面增强设计与实现计划文档
<!-- end of auto-generated comment: release notes by coderabbit.ai -->