### PR TITLE
feat: 漫画详情页添加稍后阅读按钮

### DIFF
--- a/lib/foundation/read_later.dart
+++ b/lib/foundation/read_later.dart
@@ -52,6 +52,21 @@ class ReadLaterItem implements Comic {
     );
   }
 
+  factory ReadLaterItem.fromComicDetails(
+    ComicDetails comic,
+    String sourceKey,
+  ) {
+    return ReadLaterItem(
+      id: comic.comicId,
+      type: ComicType.fromKey(sourceKey),
+      title: comic.title,
+      subtitle: comic.subTitle,
+      cover: comic.cover,
+      sourceKey: sourceKey,
+      addedTime: DateTime.now(),
+    );
+  }
+
   @override
   String get description => subtitle ?? '';
 

--- a/lib/pages/comic_details_page/comic_page.dart
+++ b/lib/pages/comic_details_page/comic_page.dart
@@ -17,6 +17,7 @@ import 'package:venera/foundation/favorites.dart';
 import 'package:venera/foundation/history.dart';
 import 'package:venera/foundation/image_provider/cached_image.dart';
 import 'package:venera/foundation/local.dart';
+import 'package:venera/foundation/read_later.dart';
 import 'package:venera/foundation/res.dart';
 import 'package:venera/network/download.dart';
 import 'package:venera/network/cache.dart';
@@ -128,12 +129,14 @@ class _ComicPageState extends LoadingState<ComicPage, ComicDetails>
   @override
   void initState() {
     scrollController.addListener(onScroll);
+    ReadLaterManager().addListener(update);
     super.initState();
   }
 
   @override
   void dispose() {
     scrollController.removeListener(onScroll);
+    ReadLaterManager().removeListener(update);
     super.dispose();
   }
 
@@ -407,6 +410,30 @@ class _ComicPageState extends LoadingState<ComicPage, ComicDetails>
                 onPressed: openFavPanel,
                 onLongPressed: quickFavorite,
                 iconColor: context.useTextColor(Colors.purple),
+              ),
+              _ActionButton(
+                icon: const Icon(Icons.watch_later_outlined),
+                activeIcon: const Icon(Icons.watch_later),
+                isActive: ReadLaterManager().exists(
+                  comic.comicId,
+                  ComicType.fromKey(widget.sourceKey),
+                ),
+                text: 'Read Later'.tl,
+                onPressed: () {
+                  final manager = ReadLaterManager();
+                  final type = ComicType.fromKey(widget.sourceKey);
+                  if (manager.exists(comic.comicId, type)) {
+                    manager.remove(comic.comicId, type);
+                  } else {
+                    manager.add(
+                      ReadLaterItem.fromComicDetails(
+                        comic,
+                        widget.sourceKey,
+                      ),
+                    );
+                  }
+                },
+                iconColor: context.useTextColor(Colors.indigo),
               ),
               if (comicSource.commentsLoader != null)
                 _ActionButton(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 在漫画详情页面集成"稍后阅读"功能，用户可便捷地添加或移除漫画至个人阅读列表，阅读状态实时更新同步。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->