### PR TITLE
fix: 阅读器缓存过期后自动重载页面列表

### DIFF
--- a/lib/foundation/image_provider/base_image_provider.dart
+++ b/lib/foundation/image_provider/base_image_provider.dart
@@ -129,6 +129,7 @@ abstract class BaseImageProvider<T extends BaseImageProvider<T>>
         PaintingBinding.instance.imageCache.evict(key);
       });
       Log.error("Image Loading", e, s);
+      onLoadError();
       rethrow;
     } finally {
       chunkEvents.close();
@@ -156,6 +157,10 @@ abstract class BaseImageProvider<T extends BaseImageProvider<T>>
   }
 
   bool get enableResize => false;
+
+  /// Called when image loading fails after all retries are exhausted.
+  /// Subclasses can override to perform cleanup (e.g. invalidate page cache).
+  void onLoadError() {}
 }
 
 typedef FileDecoderCallback = Future<ui.Codec> Function(Uint8List);

--- a/lib/foundation/image_provider/reader_image.dart
+++ b/lib/foundation/image_provider/reader_image.dart
@@ -2,6 +2,7 @@ import 'dart:async' show Future;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_qjs/flutter_qjs.dart';
+import 'package:venera/foundation/cache_manager.dart';
 import 'package:venera/foundation/js_engine.dart';
 import 'package:venera/network/images.dart';
 import 'package:venera/utils/io.dart';
@@ -12,7 +13,7 @@ import 'package:venera/foundation/appdata.dart';
 class ReaderImageProvider
     extends BaseImageProvider<image_provider.ReaderImageProvider> {
   /// Image provider for normal image.
-  const ReaderImageProvider(this.imageKey, this.sourceKey, this.cid, this.eid, this.page, {this.enableResize = false});
+  const ReaderImageProvider(this.imageKey, this.sourceKey, this.cid, this.eid, this.page, {this.enableResize = false, this.onLoadFailed});
 
   final String imageKey;
 
@@ -23,6 +24,8 @@ class ReaderImageProvider
   final String eid;
 
   final int page;
+
+  final void Function()? onLoadFailed;
 
   @override
   final bool enableResize;
@@ -123,4 +126,11 @@ class ReaderImageProvider
 
   @override
   String get key => "$imageKey@$sourceKey@$cid@$eid@$enableResize";
+
+  @override
+  void onLoadError() {
+    var cacheKey = "loadComicPages@$sourceKey@$cid@$eid";
+    CacheManager().delete(cacheKey);
+    onLoadFailed?.call();
+  }
 }

--- a/lib/pages/reader/images.dart
+++ b/lib/pages/reader/images.dart
@@ -40,6 +40,7 @@ class _ReaderImagesState extends State<_ReaderImages> {
       error = null;
       reader.isLoading = true;
     });
+    context.readerScaffold.update();
   }
 
   /// Handle jumping to last page when _jumpToLastPageOnLoad is true

--- a/lib/pages/reader/images.dart
+++ b/lib/pages/reader/images.dart
@@ -34,6 +34,14 @@ class _ReaderImagesState extends State<_ReaderImages> {
     ImageDownloader.cancelAllLoadingImages();
   }
 
+  void _onPagesCacheInvalid() {
+    if (!mounted || inProgress) return;
+    setState(() {
+      error = null;
+      reader.isLoading = true;
+    });
+  }
+
   /// Handle jumping to last page when _jumpToLastPageOnLoad is true
   void _handleJumpToLastPage() {
     if (reader._jumpToLastPageOnLoad) {
@@ -1259,13 +1267,23 @@ ImageProvider _createImageProviderFromKey(
   int page,
 ) {
   var reader = context.reader;
+  // Find the _ReaderImagesState ancestor to get the callback
+  _ReaderImagesState? imagesState;
+  context.visitAncestorElements((element) {
+    if (element.findAncestorStateOfType<_ReaderImagesState>() != null) {
+      imagesState = element.findAncestorStateOfType<_ReaderImagesState>();
+      return false;
+    }
+    return true;
+  });
   return ReaderImageProvider(
     imageKey,
     reader.type.comicSource?.key,
     reader.cid,
     reader.eid,
     reader.page,
-    enableResize: reader.mode.isContinuous, // For continuous mode, we need to resize the image to improve performance
+    enableResize: reader.mode.isContinuous,
+    onLoadFailed: imagesState?._onPagesCacheInvalid,
   );
 }
 


### PR DESCRIPTION
fix #3   感觉没啥问题，再测测

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加可覆写的图像加载失败钩子，允许自定义失败时行为。
  * 图像提供器新增可选失败回调参数，页面层可传入处理逻辑。

* **修复/改进**
  * 加强加载失败时的缓存清理，确保失败后相关缓存条目被移除。
  * 当缓存失效触发时，阅读器界面会重置错误状态并进入加载状态，支持后续重试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->