### PR TITLE
feat: 未翻译的tag自动进行繁简转换

### DIFF
--- a/lib/pages/comic_details_page/comic_page.dart
+++ b/lib/pages/comic_details_page/comic_page.dart
@@ -682,7 +682,7 @@ class _ComicPageState extends LoadingState<ComicPage, ComicDetails>
                             tag,
                             e.key.toLowerCase(),
                           )
-                        : tag,
+                        : TagsTranslation.convertIfNeeded(tag),
                     onTap: () => onTapTag(tag, e.key),
                   ),
               ],

--- a/lib/utils/tags_translation.dart
+++ b/lib/utils/tags_translation.dart
@@ -10,6 +10,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:venera/foundation/app.dart';
 import 'package:venera/utils/ext.dart';
+import 'package:venera/utils/opencc.dart';
 
 extension TagsTranslation on String{
   static final Map<String, Map<String, String>> _data = {};
@@ -32,22 +33,34 @@ extension TagsTranslation on String{
     return _data.containsKey(key);
   }
 
+  /// 对文本进行繁简转换，简中locale转简体，繁中locale转繁体，其他locale不处理
+  static String convertIfNeeded(String text) {
+    var locale = App.locale;
+    if (locale.languageCode != "zh") return text;
+    if (locale.countryCode == "TW") {
+      return OpenCC.simplifiedToTraditional(text);
+    } else {
+      return OpenCC.traditionalToSimplified(text);
+    }
+  }
+
   /// 对tag进行处理后进行翻译: 代表'或'的分割符'|', namespace.
   static String _translateTags(String tag){
     if (tag.contains('|')) {
       var splits = tag.split('|');
-      return enTagsTranslations[splits[0].trim()]
-          ?? enTagsTranslations[splits[1].trim()]
-          ?? tag;
+      var result = enTagsTranslations[splits[0].trim()]
+          ?? enTagsTranslations[splits[1].trim()];
+      if (result != null) return result;
+      return convertIfNeeded(tag);
     } else if(tag.contains(':')) {
       var splits = tag.split(':');
       if(_haveNamespace(splits[0])) {
         return translationTagWithNamespace(splits[1], splits[0]);
       } else {
-        return tag;
+        return convertIfNeeded(tag);
       }
     } else {
-      return enTagsTranslations[tag]??tag;
+      return enTagsTranslations[tag] ?? convertIfNeeded(tag);
     }
   }
 
@@ -77,20 +90,21 @@ extension TagsTranslation on String{
     if(text != "reclass" && text.endsWith('s')){
       text.replaceLast('s', '');
     }
-    return switch(namespace){
-      "male" => maleTags[text] ?? text,
-      "female" => femaleTags[text] ?? text,
-      "mixed" => mixedTags[text] ?? text,
-      "other" => otherTags[text] ?? text,
-      "parody" => parodyTags[text] ?? text,
-      "character" => characterTranslations[text] ?? text,
-      "group" => groupTags[text] ?? text,
-      "cosplayer" => cosplayerTags[text] ?? text,
-      "reclass" => reclassTags[text] ?? text,
-      "language" => languageTranslations[text] ?? text,
-      "artist" => artistTags[text] ?? text,
+    var result = switch(namespace){
+      "male" => maleTags[text],
+      "female" => femaleTags[text],
+      "mixed" => mixedTags[text],
+      "other" => otherTags[text],
+      "parody" => parodyTags[text],
+      "character" => characterTranslations[text],
+      "group" => groupTags[text],
+      "cosplayer" => cosplayerTags[text],
+      "reclass" => reclassTags[text],
+      "language" => languageTranslations[text],
+      "artist" => artistTags[text],
       _ => text.translateTagsToCN
     };
+    return result ?? convertIfNeeded(text);
   }
 
   String _categoryTextDynamic(String c){


### PR DESCRIPTION
漫画源返回的繁体中文tag在翻译表未命中时，现在会通过OpenCC
自动转换为对应locale的字体，而非直接显示原文。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 添加了中文简繁体转换支持，根据用户语言偏好自动进行转换。

* **Bug Fixes**
  * 改进了标签显示逻辑，在禁用翻译时采用更恰当的处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->