### PR TITLE
feat: 优化设置页面

### DIFF
--- a/lib/pages/settings/app.dart
+++ b/lib/pages/settings/app.dart
@@ -76,25 +76,15 @@ class _AppSettingsState extends State<AppSettings> {
             setState(() {});
           },
         ).toSliver(),
-        _CallbackSetting(
+        _SliderSetting(
           title: "Cache Limit".tl,
-          subtitle: "${appdata.settings['cacheSize']} MB",
-          callback: () {
-            showInputDialog(
-              context: context,
-              title: "Set Cache Limit".tl,
-              hintText: "Size in MB".tl,
-              inputValidator: RegExp(r"^\d+$"),
-              onConfirm: (value) {
-                appdata.settings['cacheSize'] = int.parse(value);
-                appdata.saveData();
-                setState(() {});
-                CacheManager().setLimitSize(appdata.settings['cacheSize']);
-                return null;
-              },
-            );
+          settingsIndex: "cacheSize",
+          interval: 256,
+          min: 256,
+          max: 8192,
+          onChanged: () {
+            CacheManager().setLimitSize(appdata.settings['cacheSize']);
           },
-          actionTitle: 'Set'.tl,
         ).toSliver(),
         _CallbackSetting(
           title: "Export App Data".tl,
@@ -155,6 +145,16 @@ class _AppSettingsState extends State<AppSettings> {
           },
           onChanged: () {
             App.forceRebuild();
+          },
+        ).toSliver(),
+        SelectSetting(
+          title: "Initial Page".tl,
+          settingKey: "initialPage",
+          optionTranslation: {
+            '0': "Home Page".tl,
+            '1': "Favorites Page".tl,
+            '2': "Explore Page".tl,
+            '3': "Categories Page".tl,
           },
         ).toSliver(),
         if (!App.isLinux)
@@ -353,7 +353,6 @@ class _WebdavSettingState extends State<_WebdavSetting> {
   String url = "";
   String user = "";
   String pass = "";
-  String disableSync = "";
 
   bool autoSync = true;
 
@@ -365,9 +364,6 @@ class _WebdavSettingState extends State<_WebdavSetting> {
     super.initState();
     if (appdata.settings['webdav'] is! List) {
       appdata.settings['webdav'] = [];
-    }
-    if (appdata.settings['disableSyncFields'].trim().isNotEmpty) {
-      disableSync = appdata.settings['disableSyncFields'];
     }
     var configs = appdata.settings['webdav'] as List;
     if (configs.whereType<String>().length != 3) {
@@ -421,56 +417,6 @@ class _WebdavSettingState extends State<_WebdavSetting> {
               ),
               controller: TextEditingController(text: pass),
               onChanged: (value) => pass = value,
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              decoration: InputDecoration(
-                labelText: "Skip Setting Fields (Optional)".tl,
-                hintText: "field0, field1, field2, ...",
-                hintStyle: TextStyle(color: Theme.of(context).hintColor),
-                border: OutlineInputBorder(),
-                suffixIcon: IconButton(
-                  icon: Icon(Icons.help_outline),
-                  onPressed: () {
-                    showDialog(
-                      context: context,
-                      builder: (_) => AlertDialog(
-                        title: Text("Skip Setting Fields".tl),
-                        content: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              "When sync data, skip certain setting fields, which means these won't be uploaded / override.".tl,
-                            ),
-                            const SizedBox(height: 12),
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    "See source code for available fields.".tl,
-                                  ),
-                                ),
-                                Align(
-                                  alignment: Alignment.centerRight,
-                                  child: IconButton(
-                                    icon: const Icon(Icons.open_in_new),
-                                    onPressed: () {
-                                      launchUrlString("https://github.com/haukuen/venera/blob/main/lib/foundation/appdata.dart");
-                                    },
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
-                ),
-              ),
-              controller: TextEditingController(text: disableSync),
-              onChanged: (value) => disableSync = value,
             ),
             const SizedBox(height: 12),
             ListTile(
@@ -549,7 +495,6 @@ class _WebdavSettingState extends State<_WebdavSetting> {
                   }
 
                   appdata.settings['webdav'] = [url, user, pass];
-                  appdata.settings['disableSyncFields'] = disableSync;
                   appdata.implicitData['webdavAutoSync'] = autoSync;
                   appdata.writeImplicitData();
 

--- a/lib/pages/settings/appearance.dart
+++ b/lib/pages/settings/appearance.dart
@@ -13,6 +13,10 @@ class _AppearanceSettingsState extends State<AppearanceSettings> {
     return SmoothCustomScrollView(
       slivers: [
         SliverAppbar(title: Text("Appearance".tl)),
+        _SettingPartTitle(
+          title: "Theme".tl,
+          icon: Icons.palette,
+        ),
         SelectSetting(
           title: "Theme Mode".tl,
           settingKey: "theme_mode",
@@ -40,6 +44,33 @@ class _AppearanceSettingsState extends State<AppearanceSettings> {
           onChanged: () async {
             await App.init();
             App.forceRebuild();
+          },
+        ).toSliver(),
+        _SettingPartTitle(
+          title: "Comic Display".tl,
+          icon: Icons.grid_view,
+        ),
+        SelectSetting(
+          title: "Display mode of comic tile".tl,
+          settingKey: "comicDisplayMode",
+          optionTranslation: {
+            "detailed": "Detailed".tl,
+            "brief": "Brief".tl,
+          },
+        ).toSliver(),
+        _SliderSetting(
+          title: "Size of comic tile".tl,
+          settingsIndex: "comicTileScale",
+          interval: 0.05,
+          min: 0.5,
+          max: 1.5,
+        ).toSliver(),
+        SelectSetting(
+          title: "Display mode of comic list".tl,
+          settingKey: "comicListDisplayMode",
+          optionTranslation: {
+            "paging": "Paging".tl,
+            "continuous": "Continuous".tl,
           },
         ).toSliver(),
       ],

--- a/lib/pages/settings/explore_settings.dart
+++ b/lib/pages/settings/explore_settings.dart
@@ -13,21 +13,6 @@ class _ExploreSettingsState extends State<ExploreSettings> {
     return SmoothCustomScrollView(
       slivers: [
         SliverAppbar(title: Text("Explore".tl)),
-        SelectSetting(
-          title: "Display mode of comic tile".tl,
-          settingKey: "comicDisplayMode",
-          optionTranslation: {
-            "detailed": "Detailed".tl,
-            "brief": "Brief".tl,
-          },
-        ).toSliver(),
-        _SliderSetting(
-          title: "Size of comic tile".tl,
-          settingsIndex: "comicTileScale",
-          interval: 0.05,
-          min: 0.5,
-          max: 1.5,
-        ).toSliver(),
         _PopupWindowSetting(
           title: "Explore Pages".tl,
           builder: setExplorePagesWidget,
@@ -51,10 +36,6 @@ class _ExploreSettingsState extends State<ExploreSettings> {
         _SwitchSetting(
           title: "Show history on comic tile".tl,
           settingKey: "showHistoryStatusOnTile",
-        ).toSliver(),
-        _SwitchSetting(
-          title: "Reverse default chapter order".tl,
-          settingKey: "reverseChapterOrder",
         ).toSliver(),
         _PopupWindowSetting(
           title: "Keyword blocking".tl,
@@ -86,24 +67,6 @@ class _ExploreSettingsState extends State<ExploreSettings> {
             'chinese': "Chinese",
             'english': "English",
             'japanese': "Japanese",
-          },
-        ).toSliver(),
-        SelectSetting(
-          title: "Initial Page".tl,
-          settingKey: "initialPage",
-          optionTranslation: {
-            '0': "Home Page".tl,
-            '1': "Favorites Page".tl,
-            '2': "Explore Page".tl,
-            '3': "Categories Page".tl,
-          },
-        ).toSliver(),
-        SelectSetting(
-          title: "Display mode of comic list".tl,
-          settingKey: "comicListDisplayMode",
-          optionTranslation: {
-            "paging": "Paging".tl,
-            "Continuous": "Continuous".tl,
           },
         ).toSliver(),
       ],

--- a/lib/pages/settings/network.dart
+++ b/lib/pages/settings/network.dart
@@ -261,20 +261,39 @@ class __DNSOverridesState extends State<_DNSOverrides> {
 
   @override
   void dispose() {
+    for (var entry in overrides) {
+      entry.$1.dispose();
+      entry.$2.dispose();
+    }
+    super.dispose();
+  }
+
+  void _save() {
     var map = <String, String>{};
     for (var entry in overrides) {
-      map[entry.$1.text] = entry.$2.text;
+      if (entry.$1.text.isNotEmpty && entry.$2.text.isNotEmpty) {
+        map[entry.$1.text] = entry.$2.text;
+      }
     }
     appdata.settings['dnsOverrides'] = map;
     appdata.saveData();
     JsEngine().resetDio();
-    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return PopUpWidgetScaffold(
       title: "DNS Overrides".tl,
+      tailing: [
+        TextButton.icon(
+          onPressed: () {
+            _save();
+            context.pop();
+          },
+          icon: const Icon(Icons.save),
+          label: Text("Save".tl),
+        ),
+      ],
       body: SingleChildScrollView(
         child: Column(
           children: [

--- a/lib/pages/settings/network.dart
+++ b/lib/pages/settings/network.dart
@@ -381,9 +381,10 @@ class __DNSOverridesState extends State<_DNSOverrides> {
           IconButton(
             icon: const Icon(Icons.delete_outline),
             onPressed: () {
-              setState(() {
-                overrides.removeAt(index);
-              });
+              var removed = overrides.removeAt(index);
+              removed.$1.dispose();
+              removed.$2.dispose();
+              setState(() {});
             },
           ),
         ],

--- a/lib/pages/settings/network.dart
+++ b/lib/pages/settings/network.dart
@@ -268,7 +268,7 @@ class __DNSOverridesState extends State<_DNSOverrides> {
     super.dispose();
   }
 
-  void _save() {
+  Future<void> _save() async {
     var map = <String, String>{};
     for (var entry in overrides) {
       if (entry.$1.text.isNotEmpty && entry.$2.text.isNotEmpty) {
@@ -276,7 +276,7 @@ class __DNSOverridesState extends State<_DNSOverrides> {
       }
     }
     appdata.settings['dnsOverrides'] = map;
-    appdata.saveData();
+    await appdata.saveData();
     JsEngine().resetDio();
   }
 
@@ -286,9 +286,11 @@ class __DNSOverridesState extends State<_DNSOverrides> {
       title: "DNS Overrides".tl,
       tailing: [
         TextButton.icon(
-          onPressed: () {
-            _save();
-            context.pop();
+          onPressed: () async {
+            await _save();
+            if (context.mounted) {
+              context.pop();
+            }
           },
           icon: const Icon(Icons.save),
           label: Text("Save".tl),

--- a/lib/pages/settings/reader.dart
+++ b/lib/pages/settings/reader.dart
@@ -403,6 +403,7 @@ class _ReaderSettingsState extends State<ReaderSettings> {
         ).toSliver(),
         _SliderSetting(
           title: "Number of images preloaded".tl,
+          subtitle: "Higher values use more memory".tl,
           settingsIndex: "preloadImageCount",
           interval: 1,
           min: 1,
@@ -442,6 +443,11 @@ class _ReaderSettingsState extends State<ReaderSettings> {
             useDeviceSettings: useDeviceSpecificSettings,
           ),
         ),
+        if (comicId == null)
+          _SwitchSetting(
+            title: "Reverse default chapter order".tl,
+            settingKey: "reverseChapterOrder",
+          ).toSliver(),
       ],
     );
   }

--- a/lib/pages/settings/setting_components.dart
+++ b/lib/pages/settings/setting_components.dart
@@ -381,6 +381,7 @@ class _SliderSetting extends StatefulWidget {
     required this.min,
     required this.max,
     this.onChanged,
+    this.subtitle,
     this.comicId,
     this.comicSource,
     this.useDeviceSettings = false,
@@ -398,6 +399,8 @@ class _SliderSetting extends StatefulWidget {
 
   final VoidCallback? onChanged;
 
+  final String? subtitle;
+
   final String? comicId;
 
   final String? comicSource;
@@ -409,6 +412,42 @@ class _SliderSetting extends StatefulWidget {
 }
 
 class _SliderSettingState extends State<_SliderSetting> {
+  void _setValue(double value) {
+    if (value.toInt() == value) {
+      if (widget.comicId != null) {
+        appdata.settings.setReaderSetting(
+          widget.comicId!,
+          widget.comicSource!,
+          widget.settingsIndex,
+          value.toInt(),
+        );
+      } else if (widget.useDeviceSettings) {
+        appdata.settings.setDeviceReaderSetting(
+          widget.settingsIndex,
+          value.toInt(),
+        );
+      } else {
+        appdata.settings[widget.settingsIndex] = value.toInt();
+      }
+    } else {
+      if (widget.comicId != null) {
+        appdata.settings.setReaderSetting(
+          widget.comicId!,
+          widget.comicSource!,
+          widget.settingsIndex,
+          value,
+        );
+      } else if (widget.useDeviceSettings) {
+        appdata.settings.setDeviceReaderSetting(
+          widget.settingsIndex,
+          value,
+        );
+      } else {
+        appdata.settings[widget.settingsIndex] = value;
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     var value =
@@ -425,53 +464,27 @@ class _SliderSettingState extends State<_SliderSetting> {
     return ListTile(
       title: Text(widget.title, softWrap: true, maxLines: 2),
       trailing: Text(value.toString(), style: ts.s12),
-      subtitle: Slider(
-        value: value,
-        onChanged: (value) {
-          if (value.toInt() == value) {
-            setState(() {
-              if (widget.comicId != null) {
-                appdata.settings.setReaderSetting(
-                  widget.comicId!,
-                  widget.comicSource!,
-                  widget.settingsIndex,
-                  value.toInt(),
-                );
-              } else if (widget.useDeviceSettings) {
-                appdata.settings.setDeviceReaderSetting(
-                  widget.settingsIndex,
-                  value.toInt(),
-                );
-              } else {
-                appdata.settings[widget.settingsIndex] = value.toInt();
-              }
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (widget.subtitle != null)
+            Text(widget.subtitle!, style: ts.s12),
+          Slider(
+            value: value,
+            onChanged: (value) {
+              setState(() {
+                _setValue(value);
+              });
+              widget.onChanged?.call();
+            },
+            onChangeEnd: (value) {
               appdata.saveData();
-            });
-          } else {
-            setState(() {
-              if (widget.comicId != null) {
-                appdata.settings.setReaderSetting(
-                  widget.comicId!,
-                  widget.comicSource!,
-                  widget.settingsIndex,
-                  value,
-                );
-              } else if (widget.useDeviceSettings) {
-                appdata.settings.setDeviceReaderSetting(
-                  widget.settingsIndex,
-                  value,
-                );
-              } else {
-                appdata.settings[widget.settingsIndex] = value;
-              }
-              appdata.saveData();
-            });
-          }
-          widget.onChanged?.call();
-        },
-        divisions: ((widget.max - widget.min) / widget.interval).toInt(),
-        min: widget.min,
-        max: widget.max,
+            },
+            divisions: ((widget.max - widget.min) / widget.interval).toInt(),
+            min: widget.min,
+            max: widget.max,
+          ),
+        ],
       ),
     );
   }
@@ -699,12 +712,9 @@ class _CallbackSetting extends StatelessWidget {
     required this.title,
     required this.callback,
     required this.actionTitle,
-    this.subtitle,
   });
 
   final String title;
-
-  final String? subtitle;
 
   final VoidCallback callback;
 
@@ -714,7 +724,6 @@ class _CallbackSetting extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
       title: Text(title),
-      subtitle: subtitle == null ? null : Text(subtitle!),
       trailing: Button.normal(
         onPressed: callback,
         child: Text(actionTitle),


### PR DESCRIPTION
## Summary
- 重新分组设置项：漫画显示相关移至外观页，阅读顺序移至阅读页，初始页移至APP页
- 修复 comicListDisplayMode 选项大小写不一致
- 修复 Slider 拖动时频繁写文件，改为松手后保存
- 修复 DNS Overrides 在 dispose 中保存的副作用，改为显式保存按钮
- Cache Limit 从输入框改为 Slider
- 移除 WebDAV 同步中的跳过设置项功能（翻译不全且使用场景有限）
- 预加载图片数添加内存提示

## Test plan
- [ ] 验证外观页新增的漫画显示设置项（显示模式、缩略图大小、列表模式）正常工作
- [ ] 验证阅读页的章节顺序反转开关正常
- [ ] 验证 APP 页的初始页设置正常
- [ ] 验证 Slider 拖动时不再频繁保存，松手后才保存
- [ ] 验证 DNS Overrides 的保存按钮正常工作
- [ ] 验证 Cache Limit Slider 正常调节
- [ ] 验证 comicListDisplayMode 选项值正确（小写 continuous）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 缓存限制现支持滑块调整（256–8192MB）
  * 新增初始页面选择设置
  * 外观设置新增漫画显示模式、瓦片缩放与列表显示方式选项

* **改进**
  * 阅读设置：图片预加载说明更明确，新增设备级“反向默认章节顺序”开关（仅在非单漫画上下文可见）
  * 网络设置：弹窗新增“保存”操作，异步保存并过滤空白 DNS 条目，修复输入控制器释放问题
  * 滑块控件现在可显示描述文字并在调整时即时反馈

* **变更**
  * 部分显示相关设置已从探索页移除并在外观页集中展示
  * 移除探索页中用于跳过同步字段的相关输入与说明
<!-- end of auto-generated comment: release notes by coderabbit.ai -->