### PR TITLE
feat: PC端侧边栏空白区域支持拖拽移动窗口

### DIFF
--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -32,6 +32,7 @@ import 'package:venera/utils/ext.dart';
 import 'package:venera/utils/io.dart';
 import 'package:venera/utils/tags_translation.dart';
 import 'package:venera/utils/translations.dart';
+import 'package:window_manager/window_manager.dart';
 
 part 'image.dart';
 part 'appbar.dart';

--- a/lib/components/navigation_bar.dart
+++ b/lib/components/navigation_bar.dart
@@ -342,8 +342,11 @@ class NaviPaneState extends State<NaviPane>
         ),
         child: Column(
           children: [
-            const SizedBox(height: 16),
-            SizedBox(height: MediaQuery.of(context).padding.top),
+            DragToMoveArea(
+              child: SizedBox(
+                height: 16 + MediaQuery.of(context).padding.top,
+              ),
+            ),
             ...List<Widget>.generate(
               widget.paneItems.length,
               (index) => _SideNaviWidget(
@@ -356,7 +359,7 @@ class NaviPaneState extends State<NaviPane>
                 key: ValueKey(index),
               ),
             ),
-            const Spacer(),
+            const Expanded(child: DragToMoveArea(child: SizedBox.expand())),
             ...List<Widget>.generate(
               widget.paneActions.length,
               (index) => _PaneActionWidget(
@@ -365,7 +368,7 @@ class NaviPaneState extends State<NaviPane>
                 key: ValueKey(index + widget.paneItems.length),
               ),
             ),
-            const SizedBox(height: 16),
+            const DragToMoveArea(child: SizedBox(height: 16)),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- 在侧边栏的顶部间距、中间Spacer和底部间距区域添加 `DragToMoveArea`，使 PC 端用户可通过侧边栏空白区域拖拽移动窗口
- 适配 Windows/macOS/Linux 全平台，移动端不受影响

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 导航栏现已支持拖拽操作以移动窗口，改进了用户交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->