### PR TITLE
fix: 图片收藏预览支持键盘左右方向键翻页

### DIFF
--- a/lib/pages/image_favorites_page/image_favorites_photo_view.dart
+++ b/lib/pages/image_favorites_page/image_favorites_photo_view.dart
@@ -44,6 +44,7 @@ class _ImageFavoritesPhotoViewState extends State<ImageFavoritesPhotoView> {
 
   @override
   void dispose() {
+    controller.dispose();
     _focusNode.dispose();
     super.dispose();
   }

--- a/lib/pages/image_favorites_page/image_favorites_photo_view.dart
+++ b/lib/pages/image_favorites_page/image_favorites_photo_view.dart
@@ -17,6 +17,7 @@ class ImageFavoritesPhotoView extends StatefulWidget {
 
 class _ImageFavoritesPhotoViewState extends State<ImageFavoritesPhotoView> {
   late PageController controller;
+  final _focusNode = FocusNode();
   Map<ImageFavorite, bool> cancelImageFavorites = {};
 
   var images = <ImageFavorite>[];
@@ -39,6 +40,38 @@ class _ImageFavoritesPhotoViewState extends State<ImageFavoritesPhotoView> {
     currentPage = current;
     controller = PageController(initialPage: current);
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (HardwareKeyboard.instance.isControlPressed) {
+      return KeyEventResult.ignored;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+      if (controller.page! >= images.length - 1) {
+        return KeyEventResult.handled;
+      }
+      controller.nextPage(
+          duration: Duration(milliseconds: 180), curve: Curves.ease);
+      return KeyEventResult.handled;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+      if (controller.page! <= 0) {
+        return KeyEventResult.handled;
+      }
+      controller.previousPage(
+          duration: Duration(milliseconds: 180), curve: Curves.ease);
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
   }
 
   void onPop() {
@@ -81,7 +114,11 @@ class _ImageFavoritesPhotoViewState extends State<ImageFavoritesPhotoView> {
           onPop();
         }
       },
-      child: Listener(
+      child: Focus(
+        focusNode: _focusNode,
+        autofocus: true,
+        onKeyEvent: _handleKeyEvent,
+        child: Listener(
         onPointerSignal: (event) {
           if (HardwareKeyboard.instance.isControlPressed) {
             return;
@@ -140,6 +177,7 @@ class _ImageFavoritesPhotoViewState extends State<ImageFavoritesPhotoView> {
             child: buildAppBar(),
           ),
         ]),
+        ),
       ),
     );
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在图片收藏页面加入键盘导航：左右箭头可切换图片，达到首尾时不会越界。
  * 页面自动聚焦以便立即响应键盘操作；按住 Control 键时不会触发导航，其他非方向键也被忽略，且保留原有鼠标滚动行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->