### PR TITLE
fix: 修复安卓/iOS收藏夹漫画拖动排序失效

### DIFF
--- a/lib/components/comic.dart
+++ b/lib/components/comic.dart
@@ -51,8 +51,12 @@ class _TapScaleBuilderState extends State<_TapScaleBuilder> {
       onTapDown: (_) => setState(() => _pressed = true),
       onTapUp: (_) => setState(() => _pressed = false),
       onTapCancel: () => setState(() => _pressed = false),
-      onLongPressStart: (_) => setState(() => _pressed = true),
-      onLongPressEnd: (_) => setState(() => _pressed = false),
+      onLongPressStart: widget.onLongPress != null
+          ? (_) => setState(() => _pressed = true)
+          : null,
+      onLongPressEnd: widget.onLongPress != null
+          ? (_) => setState(() => _pressed = false)
+          : null,
       child: AnimatedScale(
         scale: _pressed ? 0.97 : 1.0,
         duration: const Duration(milliseconds: 100),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化长按动画：长按按压状态动画现在仅在配置长按回调时触发，避免不必要的动画效果。点击行为保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->