### PR TITLE
fix: 首页卡片内容左对齐 (#28)

### DIFF
--- a/lib/components/home_section_card.dart
+++ b/lib/components/home_section_card.dart
@@ -33,6 +33,7 @@ class HomeSectionCard extends StatelessWidget {
         onTap: onTap,
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             _buildTitleRow(context),
             if (content != null) content!,


### PR DESCRIPTION
close #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式优化**
  * 调整卡片组件内容的对齐方式，确保标题行和相关元素左对齐显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->