### PR TITLE
Fix iOS export dialog not work

### DIFF
--- a/lib/utils/io.dart
+++ b/lib/utils/io.dart
@@ -356,7 +356,11 @@ Future<void> saveFile({
       file = File(cache);
     }
     if (App.isMobile) {
-      final params = SaveFileDialogParams(sourceFilePath: file!.path);
+      // FIX: iOS export dialog cannot show filename and save.
+      final params = SaveFileDialogParams(
+        sourceFilePath: file!.path,
+        fileName: filename
+      );
       await FlutterFileDialog.saveFile(params: params);
     } else {
       final result = await file_selector.getSaveLocation(

--- a/lib/utils/io.dart
+++ b/lib/utils/io.dart
@@ -359,7 +359,7 @@ Future<void> saveFile({
       // FIX: iOS export dialog cannot show filename and save.
       final params = SaveFileDialogParams(
         sourceFilePath: file!.path,
-        fileName: filename
+        fileName: App.isIOS ? filename : null,
       );
       await FlutterFileDialog.saveFile(params: params);
     } else {


### PR DESCRIPTION
上游存档了，感谢老哥最近的维护🙏

这个 PR 修复 iOS 下载图片无法保存的问题，该问题只出现在 iOS/iPad OS上，实际测试 Android 和 Mac 没有这个问题（手边没有windows，没有测试windows）

## 问题截图
![image](https://github.com/user-attachments/assets/8ac0d719-e6c9-42d4-a969-f502b8844c13)

## 修复后截图

![image](https://github.com/user-attachments/assets/71a280e8-94a8-44eb-95d1-0a3a44b688a5)

## 改动

多传一个文件名，让 iOS 处理dialog 的时候走复制分支逻辑，这样可以绕开无法保存的问题

```swift
// ~/.pub-cache/hosted/pub.dev/flutter_file_dialog-3.0.3/ios/Classes/SaveFileDialog.swift
    func saveFile(_ params: SaveFileDialogParams, result: @escaping FlutterResult) {
        flutterResult = result
        self.params = params
        writeLog(buildParameterLog(params))

        var fileUrl: URL?

        if params.data == nil {
            // get source file URL
            guard let sourceFilePath = params.sourceFilePath else {
                result(FlutterError(code: "invalid_arguments",
                                    message: "Missing 'sourceFilePath'",
                                    details: nil)
                )
                return
            }

            // note: fileExists fails if path contains relative elements, so standardize the path
            fileUrl = URL(fileURLWithPath: sourceFilePath).standardized
            writeLog(describeUrl("sourceFileUrl", fileUrl!))

            // check that source file exists
            if !FileManager.default.fileExists(atPath: fileUrl!.path) {
                result(FlutterError(code: "file_not_found",
                                    message: "File not found: '\(fileUrl!.path)'",
                                    details: nil)
                )
                return
            }
        }

        // if file name was specified, create a temp file with the requested file name
        if params.fileName != nil {
            let directory = NSTemporaryDirectory()
            tempFileUrl = NSURL.fileURL(withPathComponents: [directory, params.fileName!])
            writeLog(describeUrl("tempFileUrl", tempFileUrl!))

            do {
                // overwrite existing file
                if FileManager.default.fileExists(atPath: tempFileUrl!.path) {
                    try FileManager.default.removeItem(at: tempFileUrl!)
                }

                if params.data != nil {
                    writeLog("Writing data \(params.data!.count) bytes to temp file \(tempFileUrl!)")
                    let d = Data(bytes: params.data!, count: params.data!.count)
                    try d.write(to: tempFileUrl!)
                } else {
                    writeLog("Copying \(fileUrl!) to \(tempFileUrl!)")
                    try FileManager.default.copyItem(at: fileUrl!, to: tempFileUrl!)
                }
            } catch {
                writeLog(error.localizedDescription)
                result(FlutterError(code: "creating_temp_file_failed",
                                    message: error.localizedDescription,
                                    details: nil)
                )
                return
            }
            fileUrl = tempFileUrl!
        }

        writeLog(describeUrl("documentPickerExportUrl", fileUrl!))

        // get parent view controller
        guard let parentViewController = UIApplication.shared.keyWindow?.rootViewController else {
            result(FlutterError(code: "fatal",
                                message: "Getting rootViewController failed",
                                details: nil)
            )
            return
        }

        // create document picker
        let documentPickerViewController = UIDocumentPickerViewController(url: fileUrl!, in: .exportToService)
        documentPickerViewController.delegate = self

        // show dialog
        parentViewController.present(documentPickerViewController, animated: true, completion: nil)
    }
 ```

因为这个问题没有任何报错日志，一开始我还以为是文件名称超长的问题，后来发现不是，再底层就不知道iOS内部是怎么处理这个问题的了。