### PR TITLE
fix: export filename invalid, chapter title for display and export

### DIFF
--- a/lib/pages/comic_details_page/cover_viewer.dart
+++ b/lib/pages/comic_details_page/cover_viewer.dart
@@ -133,7 +133,8 @@ class _CoverViewerState extends State<_CoverViewer> {
       final data = await completer.future;
       final fileType = detectFileType(data);
       await saveFile(
-        filename: "cover_${sanitizeFileName(widget.title, maxLength: maxSanitizedFileNameLength)}${fileType.ext}",
+        filename:
+            "cover_${sanitizeFileName(widget.title, maxLength: maxSanitizedFileNameLength)}${fileType.ext}",
         data: data,
       );
     } catch (e) {

--- a/lib/pages/comic_details_page/cover_viewer.dart
+++ b/lib/pages/comic_details_page/cover_viewer.dart
@@ -133,7 +133,7 @@ class _CoverViewerState extends State<_CoverViewer> {
       final data = await completer.future;
       final fileType = detectFileType(data);
       await saveFile(
-        filename: "cover_${widget.title}${fileType.ext}",
+        filename: "cover_${sanitizeFileName(widget.title, maxLength: maxSanitizedFileNameLength)}${fileType.ext}",
         data: data,
       );
     } catch (e) {

--- a/lib/pages/local_comics_page.dart
+++ b/lib/pages/local_comics_page.dart
@@ -549,7 +549,7 @@ class _LocalComicsPageState extends State<LocalComicsPage> {
       for (var comic in comics) {
         fileName = FilePath.join(
           cacheDir,
-          sanitizeFileName(comic.title, maxLength: 100) + ext,
+          sanitizeFileName(comic.title, maxLength: 50) + ext,
         );
         await export(comic, fileName);
         current++;

--- a/lib/pages/local_comics_page.dart
+++ b/lib/pages/local_comics_page.dart
@@ -549,7 +549,7 @@ class _LocalComicsPageState extends State<LocalComicsPage> {
       for (var comic in comics) {
         fileName = FilePath.join(
           cacheDir,
-          sanitizeFileName(comic.title, maxLength: 50) + ext,
+          sanitizeFileName(comic.title, maxLength: maxSanitizedFileNameLength) + ext,
         );
         await export(comic, fileName);
         current++;

--- a/lib/pages/local_comics_page.dart
+++ b/lib/pages/local_comics_page.dart
@@ -549,7 +549,8 @@ class _LocalComicsPageState extends State<LocalComicsPage> {
       for (var comic in comics) {
         fileName = FilePath.join(
           cacheDir,
-          sanitizeFileName(comic.title, maxLength: maxSanitizedFileNameLength) + ext,
+          sanitizeFileName(comic.title, maxLength: maxSanitizedFileNameLength) +
+              ext,
         );
         await export(comic, fileName);
         current++;

--- a/lib/pages/reader/reader.dart
+++ b/lib/pages/reader/reader.dart
@@ -170,6 +170,11 @@ class _ReaderState extends State<Reader>
 
   String get eid => widget.chapters?.ids.elementAtOrNull(chapter - 1) ?? '0';
 
+  String? get chapterTitle =>
+      widget.chapters?.titles.elementAtOrNull(chapter - 1);
+
+  String get chapterDisplayName => chapterTitle ?? 'E$chapter';
+
   @override
   List<String>? images;
 

--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -691,7 +691,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     // Save file name: ComicName_EP{chapter}_P{page}.{ext} to avoid conflict.
     // The chapter index of different group is continuous, so we use chapter number is enough.
     var filename =
-        "${sanitizeFileName(context.reader.widget.name, maxLength: 50)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
+        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
     saveFile(data: data, filename: filename);
   }
 
@@ -704,7 +704,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
     var filename =
-        "${sanitizeFileName(context.reader.widget.name, maxLength: 50)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
+        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
     Share.shareFile(data: data, filename: filename, mime: fileType.mime);
   }
 

--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -679,7 +679,8 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
     // Save file name: ComicName_EP{chapter}_P{page}.{ext} to avoid conflict.
-    // The chapter index of different group is continuous, so we use chapter number is enough.
+    // To avoid the file name being too long, here only keep the first characters define by maxSanitizedFileNameLength
+    // To keep the chapter show right with comic(define by sources), we use chapterDisplayName, if undefined, we use chapter number instead.
     var filename =
         "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapterDisplayName}_P${imageIndex + 1}${fileType.ext}";
     saveFile(data: data, filename: filename);

--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -670,6 +670,16 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     );
   }
 
+  /// Build export filename: {ComicName}_EP{Chapter}_P{Page}.{ext}
+  String _exportFilename(int page, String ext) {
+    var raw =
+        "${context.reader.widget.name}_EP${context.reader.chapterDisplayName}_P$page$ext";
+    return sanitizeFileName(
+      raw,
+      maxLength: maxSanitizedFileNameLength + ext.length + 30,
+    );
+  }
+
   void saveCurrentImage() async {
     var result = await selectImageToData();
     if (result == null) {
@@ -678,11 +688,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     if (!mounted) return;
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
-    // Save file name: ComicName_EP{chapter}_P{page}.{ext} to avoid conflict.
-    // To avoid the file name being too long, here only keep the first characters define by maxSanitizedFileNameLength
-    // To keep the chapter show right with comic(define by sources), we use chapterDisplayName, if undefined, we use chapter number instead.
-    var filename =
-        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapterDisplayName}_P${imageIndex + 1}${fileType.ext}";
+    var filename = _exportFilename(imageIndex + 1, fileType.ext);
     saveFile(data: data, filename: filename);
   }
 
@@ -694,8 +700,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     if (!mounted) return;
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
-    var filename =
-        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapterDisplayName}_P${imageIndex + 1}${fileType.ext}";
+    var filename = _exportFilename(imageIndex + 1, fileType.ext);
     Share.shareFile(data: data, filename: filename, mime: fileType.mime);
   }
 

--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -196,9 +196,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
   }
 
   Widget buildTop() {
-    final epName = context.reader.widget.chapters?.titles.elementAtOrNull(
-      context.reader.chapter - 1,
-    );
+    final epName = context.reader.chapterTitle;
 
     return BlurEffect(
       child: Container(
@@ -304,11 +302,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
       List<String> tags = context.reader.widget.tags;
       String author = context.reader.widget.author;
 
-      var epName =
-          context.reader.widget.chapters?.titles.elementAtOrNull(
-            context.reader.chapter - 1,
-          ) ??
-          "E${context.reader.chapter}";
+      var epName = context.reader.chapterDisplayName;
       var translatedTags = tags.map((e) => e.translateTagsToCN).toList();
 
       if (isLiked()) {
@@ -413,7 +407,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
   Widget buildBottom() {
     // Use maxPage for display (excluding chapter comments page)
     final displayPage = context.reader.page.clamp(1, context.reader.maxPage);
-    var text = "E${context.reader.chapter} : P$displayPage";
+    var text = "${context.reader.chapterDisplayName} : P$displayPage";
     if (context.reader.widget.chapters == null) {
       text = "P$displayPage";
     }
@@ -619,11 +613,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
   }
 
   Widget buildPageInfoText() {
-    var epName =
-        context.reader.widget.chapters?.titles.elementAtOrNull(
-          context.reader.chapter - 1,
-        ) ??
-        "E${context.reader.chapter}";
+    var epName = context.reader.chapterDisplayName;
     if (epName.length > 8) {
       epName = "${epName.substring(0, 8)}...";
     }
@@ -691,7 +681,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     // Save file name: ComicName_EP{chapter}_P{page}.{ext} to avoid conflict.
     // The chapter index of different group is continuous, so we use chapter number is enough.
     var filename =
-        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
+        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapterDisplayName}_P${imageIndex + 1}${fileType.ext}";
     saveFile(data: data, filename: filename);
   }
 
@@ -704,7 +694,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
     var filename =
-        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
+        "${sanitizeFileName(context.reader.widget.name, maxLength: maxSanitizedFileNameLength)}_EP${context.reader.chapterDisplayName}_P${imageIndex + 1}${fileType.ext}";
     Share.shareFile(data: data, filename: filename, mime: fileType.mime);
   }
 

--- a/lib/pages/reader/scaffold.dart
+++ b/lib/pages/reader/scaffold.dart
@@ -691,7 +691,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     // Save file name: ComicName_EP{chapter}_P{page}.{ext} to avoid conflict.
     // The chapter index of different group is continuous, so we use chapter number is enough.
     var filename =
-        "${context.reader.widget.name}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
+        "${sanitizeFileName(context.reader.widget.name, maxLength: 50)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
     saveFile(data: data, filename: filename);
   }
 
@@ -704,7 +704,7 @@ class _ReaderScaffoldState extends State<_ReaderScaffold> {
     var (imageIndex, data) = result;
     var fileType = detectFileType(data);
     var filename =
-        "${context.reader.widget.name}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
+        "${sanitizeFileName(context.reader.widget.name, maxLength: 50)}_EP${context.reader.chapter}_P${imageIndex + 1}${fileType.ext}";
     Share.shareFile(data: data, filename: filename, mime: fileType.mime);
   }
 

--- a/lib/utils/cbz.dart
+++ b/lib/utils/cbz.dart
@@ -140,7 +140,10 @@ abstract class CBZ {
     }
     Map<String, String>? cpMap;
     var dest = Directory(
-      FilePath.join(LocalManager().path, sanitizeFileName(metaData.title)),
+      FilePath.join(
+        LocalManager().path,
+        sanitizeFileName(metaData.title, maxLength: maxSanitizedFileNameLength),
+      ),
     );
     dest.createSync();
     coverFile.copyMem(FilePath.join(dest.path, 'cover.${coverFile.extension}'));

--- a/lib/utils/io.dart
+++ b/lib/utils/io.dart
@@ -135,6 +135,9 @@ extension DirectoryExtension on Directory {
   }
 }
 
+/// The maximum length of a sanitized file name.
+const maxSanitizedFileNameLength = 50;
+
 /// Sanitize the file name. Remove invalid characters and trim the file name.
 String sanitizeFileName(String fileName, {String? dir, int? maxLength}) {
   while (fileName.endsWith('.')) {

--- a/lib/utils/io.dart
+++ b/lib/utils/io.dart
@@ -135,8 +135,14 @@ extension DirectoryExtension on Directory {
   }
 }
 
-/// The maximum length of a sanitized file name.
-const maxSanitizedFileNameLength = 50;
+/// The maximum length of a sanitized file name title portion.
+///
+/// APFS (iOS/macOS) limits filenames to 255 UTF-8 bytes. After reserving space
+/// for suffixes like `_EP{chapter}_P{page}.{ext}` (~80 bytes worst case),
+/// this leaves ~175 bytes for the title. At 3 bytes per CJK character, that's
+/// ~58 pure CJK chars. 80 chars works for mixed CJK/ASCII titles in practice.
+/// See also: [comicDirectoryMaxLength] in local.dart which uses the same value.
+const maxSanitizedFileNameLength = 80;
 
 /// Sanitize the file name. Remove invalid characters and trim the file name.
 String sanitizeFileName(String fileName, {String? dir, int? maxLength}) {


### PR DESCRIPTION
## 修复问题

### 导出文件名清洗

导出的文件命名原本为直接拼接，在一些命名比较奇怪的漫画里面就会出现问题，比如：

```
侯爵嫡男好色物語 ～異世界後宮英雄戰記～[AL/GEN] 侯爵嫡男好色物語 ～異世界ハーレム英雄戰記～
```

点击下载按钮会直接后台报错，前端没有任何反应：

```
flutter: PathNotFoundException: Cannot open file, path = '/Users/bgzo/Library/Containers/io.github.haukuen.venera/Data/Library/Caches/io.github.haukuen.venera/侯爵嫡男好色物語 ～異世界後宮英雄戰記～[AL/GEN] 侯爵嫡男好色物語 ～異世界ハーレム英雄戰記～_EP1_P13.png' (OS Error: No such file or directory, errno = 2)
flutter: #0      _checkForErrorResponse (dart:io/common.dart:58:9)
flutter: #1      _File.open.<anonymous closure> (dart:io/file_impl.dart:438:7)
flutter: #2      _rootRunUnary (dart:async/zone_root.dart:48:47)
flutter: #3      _CustomZone.runUnary (dart:async/zone.dart:733:19)
flutter: <asynchronous suspension>
flutter: #4      _File.writeAsBytes.<anonymous closure> (dart:io/file_impl.dart:728:34)
flutter: <asynchronous suspension>
flutter: #5      saveFile (package:venera/utils/io.dart:359:7)
flutter: <asynchronous suspension>
flutter:  
```

### 导出文件名长度限制到50

因为我的设备主要是iPad，在对一些超长文件名进行保存的时候，会自动进行截断，比如：

```
與明明看起來很清純卻用下流的言辭呻吟起來的鄰家巨乳大姐姐濃厚親密恩愛性愛的故事 [ひつじのうどん屋 (いなみみ)] 清楚っぽいのに下品な言葉づかいでオホ喘ぎしちゃう近所の巨乳お姉さんと濃厚いちゃラブえっちする話 [中國翻譯] [禁漫去碼]_EP1_P1.png
```

最终会被系统直接截断为：

```
與明明看起來很清純卻用下流的言辭呻吟起來的鄰家巨乳大姐姐濃厚親密恩愛性愛的故事 [ひつじのうどん屋 (いなみみ)] 清楚っぽいのに下品な言葉づかいでオホ喘ぎしちゃう.png
```

章节和集数丢了，最近才发现😭，因此考虑把漫画名截取限制为 50 个字符


### Append: 章节显示的问题

现在章节显示下方直接展示的是 id，不是实际的漫画章节，比如葬送的芙莉莲最新话147，下方展示的 EP 是158，导出的文件名的 EP 也是错的。

<img width="1112" height="889" alt="图片" src="https://github.com/user-attachments/assets/59f879bc-b4ee-4bd5-8879-c6858c790c82" />

修复后：

<img width="1112" height="889" alt="图片" src="https://github.com/user-attachments/assets/9c29fb48-98ad-4e15-9f5c-bfd768bf49b0" />

## 如何修复：

1. 上述示例的非法字符是 `/`，识别成了目录，这里调用原本的 sanitizeFileName 格式化函数即可修复。
2. 考虑到多设备兼容的问题，最终保守预留50个字符给漫画标题，超长的截断处理，已提取常量到 io.dart，后续按需修改；
3. 多抽象了两个变量名 chapterTitle、chapterDisplayName 用于修正这里的显示，其他逻辑保持不变；
